### PR TITLE
Roulette 

### DIFF
--- a/src/.parsed-git 3.json
+++ b/src/.parsed-git 3.json
@@ -1,0 +1,1 @@
+{"git_commit_hash":"f5c3616413334a62526eba188249fc21cd748574","git_branch":"master"}

--- a/src/.parsed-git.json
+++ b/src/.parsed-git.json
@@ -1,2 +1,1 @@
-{"git_commit_hash":"5e5cb77c86b406e9634924866e5ebd533212b411","git_branch":"fix_manageToken_list"}
-
+{"git_commit_hash":"f87a73224119bcbc6f7b0432cdff5893e1309b1d","git_branch":"roulette_rNd"}

--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -163,8 +163,8 @@ export default function CurrencyInputPanel({
     setModalOpen(false)
   }, [setModalOpen])
 
-  const toUsdc = useUSDCPrice(currency)
-  console.log(toUsdc)
+  const toUsdc = useUSDCPrice(currency) 
+  
   return (
     <InputPanel id={id}>
       <Container hideInput={hideInput}>

--- a/src/state/swap/reducer.ts
+++ b/src/state/swap/reducer.ts
@@ -52,7 +52,7 @@ export default createReducer<SwapState>(initialState, builder =>
           ...state,
           independentField: state.independentField === Field.INPUT ? Field.OUTPUT : Field.INPUT,
           [field]: { currencyId: currencyId },
-          [otherField]: { currencyId: state[field].currencyId }
+          [otherField]: { currencyId: currencyId }
         }
       } else {
         // the normal case

--- a/src/utils/useUSDCPrice.ts
+++ b/src/utils/useUSDCPrice.ts
@@ -61,6 +61,6 @@ export default function useUSDCPrice(currency?: Currency): Price | undefined {
         return new Price(currency, USDC, usdcPrice.denominator, usdcPrice.numerator)
       }
     }
-    return undefined
+    return new Price(USDC, USDC, '1', '1')
   }, [chainId, currency, ethPair, ethPairState, usdcEthPair, usdcEthPairState, usdcPair, usdcPairState, wrapped])
 }


### PR DESCRIPTION
* Add USDC price display

This commit adds the USDC Price to the advanced swap details when a user initiates a swap. Shows whatever the Input token is in USDC. Also correct about page info.

* Correct Token analytics info

This commit allows for the FISH token contract stats to be displayed when the user clicks the 'fish' icon. Page no longer refreshes after user clicks icon, and errors are no longer present.

* UI Corrections

Correct text color the the "Analytics" links in the 🐟info / analytics modal

Corrects "Pending" transaction text in light mode to be visible

* Correct USDC amount info

This commit corrects the info in the Advanced Swap Details to be more specific about the USDC price of token A

* Merge with PP DEV master

* Update Swap details

- Adds USDC trade amounts for both input and output tokens
- Updates advaced swap details:
  - rate, inverse rate, USD rate, also adds USD amount of 'minimum
  received'

* Correct manageToken scroll issue

- Adds `overflow: scroll` to TokenList Wrapper CSS
- Add `position: bottom` to the footer in the ManageTokens
  token list modal

V5.7

* Corrects bug found w/ useUSDCPrice functionality

* Roulette
- Sets [otherField]: { currencyId: currencyId } in
src/state/swap/reducer.ts

V1.2



Co-authored-by: David E. Felton <hiturunk@gmail.com>